### PR TITLE
fix sails-disk version

### DIFF
--- a/optional-files/persistence/index.js
+++ b/optional-files/persistence/index.js
@@ -2,7 +2,7 @@
 
 
 module.exports.injectContext = function(context) {
-    context.config.dependencies['sails-disk'] = '*';
+    context.config.dependencies['sails-disk'] = '0.10.10';
 
     return context;
 };


### PR DESCRIPTION
This closes #10 by fixing the version of sails-disk to the latest supported by old Waterline.